### PR TITLE
job queue callback WIP

### DIFF
--- a/sihl/src/contract_queue.ml
+++ b/sihl/src/contract_queue.ml
@@ -133,6 +133,9 @@ module type Sig = sig
   (** [dispatch ?ctx ?delay input job] queues [job] for later processing and
       returns [unit Lwt.t] once the job has been queued.
 
+      An optional [callback] function that will be called after the job has been
+      enqueued.
+
       An optional [delay] determines the amount of time from now (when dispatch
       is called) up until the job can be run. If no delay is specified, the job
       is processed as soon as possible.
@@ -140,7 +143,8 @@ module type Sig = sig
       [input] is the input of the [handle] function which is used for job
       processing. *)
   val dispatch
-    :  ?ctx:(string * string) list
+    :  ?callback:(instance -> unit Lwt.t)
+    -> ?ctx:(string * string) list
     -> ?delay:Ptime.span
     -> 'a
     -> 'a job
@@ -154,6 +158,9 @@ module type Sig = sig
       If the queue backend supports transactions, [dispatch_all] guarantees that
       either none or all jobs are queued.
 
+      An optional [callback] function that will be called after the jobs have been
+      enqueued.
+
       An optional [delay] determines the amount of time from now (when dispatch
       is called) up until the jobs can be run. If no delay is specified, the
       jobs are processed as soon as possible.
@@ -161,7 +168,8 @@ module type Sig = sig
       [inputs] is the input of the [handle] function. It is a list of ['a], one
       for each ['a job] instance. *)
   val dispatch_all
-    :  ?ctx:(string * string) list
+    :  ?callback:(instance -> unit Lwt.t)
+    -> ?ctx:(string * string) list
     -> ?delay:Ptime.span
     -> 'a list
     -> 'a job

--- a/sihl/test/web_csrf.ml
+++ b/sihl/test/web_csrf.ml
@@ -245,7 +245,7 @@ let post_request_both_invalid_tokens_fails _ () =
     [ CCFun.id; Sihl.Test.Session.set_value_req [ csrf_name, "garbage" ] ]
   in
   (* Cartesian product 4 requests, invalid/empty cookie and request *)
-  let reqs = CCList.product CCFun.( @@ ) add_cookie requests in
+  let reqs = CCList.product ( @@ ) add_cookie requests in
   let allowed = ref 0 in
   let handler _ =
     allowed := !allowed + 1;


### PR DESCRIPTION
We need a way to access the queue job after it has been enqueued.

I added an optional argument `callback` which takes the job instance as an argument.